### PR TITLE
port necessary macros

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
             dbt deps --target azuresql
             dbt seed --target azuresql --full-refresh
             dbt run --target azuresql --full-refresh
-            dbt test --target azuresql --schema --exclude data_test_unique_where data_test_not_null_where data_test_mutually_exclusive_ranges_no_gaps data_test_mutually_exclusive_ranges_with_gaps data_test_relationships_where_table_2 test_urls test_url_host test_url_path
+            dbt test --target azuresql --schema --exclude data_test_unique_where data_test_not_null_where data_test_mutually_exclusive_ranges_no_gaps data_test_mutually_exclusive_ranges_with_gaps data_test_relationships_where_table_2 test_urls test_url_host test_url_path data_test_at_least_one data_people data_test_expression_is_true data_test_not_constant
       
       - store_artifacts:
           path: ./logs
@@ -73,7 +73,7 @@ jobs:
             dbt deps --target synapse
             dbt seed --target synapse --full-refresh
             dbt run --target synapse --full-refresh
-            dbt test --target synapse --schema --exclude data_test_unique_where data_test_not_null_where data_test_mutually_exclusive_ranges_no_gaps data_test_mutually_exclusive_ranges_with_gaps data_test_relationships_where_table_2 test_urls test_url_host test_url_path
+            dbt test --target synapse --schema --exclude data_test_unique_where data_test_not_null_where data_test_mutually_exclusive_ranges_no_gaps data_test_mutually_exclusive_ranges_with_gaps data_test_relationships_where_table_2 test_urls test_url_host test_url_path data_test_at_least_one data_people data_test_expression_is_true data_test_not_constant
       
       - store_artifacts:
           path: ./logs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
             dbt deps --target azuresql
             dbt seed --target azuresql --full-refresh
             dbt run --target azuresql --full-refresh
-            dbt test --target azuresql --schema
+            dbt test --target azuresql --schema --exclude data_test_unique_where data_test_not_null_where data_test_mutually_exclusive_ranges_no_gaps data_test_mutually_exclusive_ranges_with_gaps data_test_relationships_where_table_2
       
       - store_artifacts:
           path: ./logs
@@ -73,7 +73,7 @@ jobs:
             dbt deps --target synapse
             dbt seed --target synapse --full-refresh
             dbt run --target synapse --full-refresh
-            dbt test --target synapse
+            dbt test --target synapse --schema --exclude data_test_unique_where data_test_not_null_where data_test_mutually_exclusive_ranges_no_gaps data_test_mutually_exclusive_ranges_with_gaps data_test_relationships_where_table_2
       
       - store_artifacts:
           path: ./logs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,46 @@
+
+version: 2.1
+
+jobs:
+  
+  integration-dbt-utils-sqlserver:
+    docker:
+      - image: dataders/pyodbc:1.2
+    steps:
+      - checkout
+      
+      - run: &pull-submodules
+          name: "Pull Submodules"
+          command: |
+            git submodule init
+            git submodule update --remote
+      
+      - run: &setup-dbt
+          name: "Setup dbt"
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install --upgrade pip setuptools
+            pip install dbt-sqlserver
+            mkdir -p ~/.dbt
+            cp integration_tests/ci/sample.profiles.yml ~/.dbt/profiles.yml
+      
+      - run:
+          name: "Run Tests - dbt-utils"
+          command: |
+            . venv/bin/activate
+            cd integration_tests/dbt_utils
+            dbt deps --target sqlserver
+            dbt seed --target sqlserver --full-refresh
+            dbt run --target sqlserver --full-refresh
+            dbt test --target sqlserver
+      
+      - store_artifacts:
+          path: ./logs
+
+
+workflows:
+  version: 2
+  test-all:
+    jobs:
+      - integration-dbt-utils-sqlserver

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
             dbt deps --target azuresql
             dbt seed --target azuresql --full-refresh
             dbt run --target azuresql --full-refresh
-            dbt test --target azuresql --schema --exclude data_test_unique_where data_test_not_null_where data_test_mutually_exclusive_ranges_no_gaps data_test_mutually_exclusive_ranges_with_gaps data_test_relationships_where_table_2
+            dbt test --target azuresql --schema --exclude data_test_unique_where data_test_not_null_where data_test_mutually_exclusive_ranges_no_gaps data_test_mutually_exclusive_ranges_with_gaps data_test_relationships_where_table_2 test_urls test_url_host test_url_path
       
       - store_artifacts:
           path: ./logs
@@ -73,7 +73,7 @@ jobs:
             dbt deps --target synapse
             dbt seed --target synapse --full-refresh
             dbt run --target synapse --full-refresh
-            dbt test --target synapse --schema --exclude data_test_unique_where data_test_not_null_where data_test_mutually_exclusive_ranges_no_gaps data_test_mutually_exclusive_ranges_with_gaps data_test_relationships_where_table_2
+            dbt test --target synapse --schema --exclude data_test_unique_where data_test_not_null_where data_test_mutually_exclusive_ranges_no_gaps data_test_mutually_exclusive_ranges_with_gaps data_test_relationships_where_table_2 test_urls test_url_host test_url_path
       
       - store_artifacts:
           path: ./logs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,13 +33,14 @@ jobs:
       
       - run:
           name: "Run Tests - dbt-utils"
+          # TODO re-implement dbt-utils's data tests
           command: |
             . venv/bin/activate
             cd integration_tests/dbt_utils
             dbt deps --target azuresql
             dbt seed --target azuresql --full-refresh
             dbt run --target azuresql --full-refresh
-            dbt test --target azuresql
+            dbt test --target azuresql --schema
       
       - store_artifacts:
           path: ./logs

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+
+target/
+dbt_modules/
+logs/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "dbt-utils"]
+	path = dbt-utils
+	url = https://github.com/fishtown-analytics/dbt-utils

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+This [dbt](https://github.com/fishtown-analytics/dbt) package contains macros 
+that:
+- can be (re)used across dbt projects running on Azure databases
+- define implementations of [dispatched macros](https://docs.getdbt.com/reference/dbt-jinja-functions/adapter/#dispatch) from other packages that can be used on a database that speaks T-SQL: SQL Server, Azure DW, Azure Synapse, ...
+
+## Installation Instructions
+
+Check [dbt Hub](https://hub.getdbt.com) for the latest installation 
+instructions, or [read the docs](https://docs.getdbt.com/docs/package-management) 
+for more information on installing packages.
+
+----
+
+## Compatibility
+
+This package provides "shims" for:
+- [dbt_utils](https://github.com/fishtown-analytics/dbt-utils) (subset: cross-db utilities)

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ This package provides "shims" for:
 
 ## Contributions
 
+### Help out!
+
+There are a number of macros that have yet to be implemented for T-SQL. Check out [this file](integration_tests/dbt_utils/dbt_project.yml) for an idea of which macros are not currently supported.
+### Multi-Adapter Support
+
 t-sql-utils applies for 2 adapters, sqlserver and synapse.
 
 Therefore, for the time being, a macro should be implemented twice, once for the functionality and once as a reference for the second adapter. 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,0 +1,5 @@
+name: 'tsql_utils'
+version: '0.1.0'
+config-version: 2
+
+require-dbt-version: ">=0.18.0"

--- a/integration_tests/.gitignore
+++ b/integration_tests/.gitignore
@@ -1,0 +1,5 @@
+
+target/
+dbt_modules/
+logs/
+env/

--- a/integration_tests/ci/sample.profiles.yml
+++ b/integration_tests/ci/sample.profiles.yml
@@ -1,0 +1,24 @@
+
+# HEY! This file is used in the tsql_utils integrations tests with CircleCI.
+# You should __NEVER__ check credentials into version control. Thanks for reading :)
+
+config:
+    send_anonymous_usage_stats: False
+    use_colors: True
+
+integration_tests:
+  target: sqlserver
+  outputs:
+  
+    sqlserver:
+      type: sqlserver
+      driver: "ODBC Driver 17 for SQL Server"
+      port: 1433
+      host: "{{ env_var('DBT_SYNAPSE_SERVER') }}"
+      database: "{{ env_var('DBT_SYNAPSE_DB') }}"
+      username: "{{ env_var('DBT_SYNAPSE_UID') }}"
+      password: "{{ env_var('DBT_SYNAPSE_PWD') }}"
+      schema: tsql_utils_integration_tests_synapse
+      encrypt: 'yes'
+      trust_cert: 'yes'
+      threads: 1

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,0 +1,3 @@
+name: 'tsql_utils_integration_tests'
+version: '0.1.0'
+config-version: 2

--- a/integration_tests/dbt_utils/dbt_project.yml
+++ b/integration_tests/dbt_utils/dbt_project.yml
@@ -1,0 +1,20 @@
+
+name: 'tsql_utils_dbt_utils_integration_tests'
+version: '1.0'
+config-version: 2
+
+profile: 'integration_tests'
+
+source-paths: ["models"]
+analysis-paths: ["analysis"] 
+test-paths: ["tests"]
+data-paths: ["data"]
+macro-paths: ["macros"]
+
+target-path: "target"  # directory which will store compiled SQL files
+clean-targets:         # directories to be removed by `dbt clean`
+    - "target"
+    - "dbt_modules"
+    
+vars:
+  dbt_utils_dispatch_list: ['tsql_utils']

--- a/integration_tests/dbt_utils/dbt_project.yml
+++ b/integration_tests/dbt_utils/dbt_project.yml
@@ -28,6 +28,8 @@ models:
       test_datediff: *disabled
       test_hash: *disabled
       test_last_day: *disabled
+      test_split_part:
+        +enabled: "{{ target.name != 'synapse' }}"
     datetime:
       test_date_spine: *disabled
     materializations: *disabled
@@ -70,6 +72,8 @@ seeds:
           updated_at: datetime
           day: date
           month: date
+      data_split_part:
+        +enabled: "{{ target.name != 'synapse' }}"
 
       data_dateadd:
         +column_types:

--- a/integration_tests/dbt_utils/dbt_project.yml
+++ b/integration_tests/dbt_utils/dbt_project.yml
@@ -25,12 +25,19 @@ models:
       +enabled: true
     datetime:
       +enabled: true
-    materializations:
-      +enabled: false
+      test_date_spine: &disabled
+        +enabled: false
+    materializations: *disabled
+      
     schema_tests:
       +enabled: false
     sql:
       +enabled: true
+      test_generate_series: *disabled
+      test_get_column_values: *disabled
+      test_get_relations_by_pattern: *disabled
+      test_get_relations_by_prefix_and_union: *disabled
+      test_groupby: *disabled
     web:
       +enabled: false
 

--- a/integration_tests/dbt_utils/dbt_project.yml
+++ b/integration_tests/dbt_utils/dbt_project.yml
@@ -22,19 +22,16 @@ vars:
 models:
   dbt_utils_integration_tests:
     cross_db_utils:
-      +enabled: true
       test_dateadd: &disabled
         +enabled: false
       test_datediff: *disabled
       test_hash: *disabled
       test_last_day: *disabled
     datetime:
-      +enabled: true
       test_date_spine: *disabled
     materializations: *disabled
       
     schema_tests:
-      # +enabled: false
       data_test_mutually_exclusive_ranges_no_gaps: *disabled
       data_test_mutually_exclusive_ranges_with_gaps: *disabled
       data_test_not_constant: *disabled
@@ -42,7 +39,6 @@ models:
       data_test_unique_where: *disabled
       data_test_not_null_where: *disabled
     sql:
-      +enabled: true
       test_generate_series: *disabled
       test_get_column_values: *disabled
       test_get_relations_by_pattern: *disabled
@@ -52,7 +48,9 @@ models:
       test_surrogate_key: *disabled
       test_union: *disabled
     web:
-      +enabled: false
+      test_url_host: *disabled
+      test_url_path: *disabled
+      test_urls: *disabled
 
 seeds:
 

--- a/integration_tests/dbt_utils/dbt_project.yml
+++ b/integration_tests/dbt_utils/dbt_project.yml
@@ -21,6 +21,7 @@ vars:
 
 models:
   dbt_utils_integration_tests:
+    +enabled: true
     cross_db_utils:
       test_dateadd: &disabled
         +enabled: false
@@ -38,6 +39,12 @@ models:
       data_test_relationships_where_table_2: *disabled
       data_test_unique_where: *disabled
       data_test_not_null_where: *disabled
+      # the following work but only when
+      # the dbt-utils submodule macros are overwritten 
+      data_test_at_least_one: *disabled
+      data_people: *disabled
+      data_test_expression_is_true: *disabled
+      data_test_not_constant: *disabled
     sql:
       test_generate_series: *disabled
       test_get_column_values: *disabled

--- a/integration_tests/dbt_utils/dbt_project.yml
+++ b/integration_tests/dbt_utils/dbt_project.yml
@@ -23,14 +23,24 @@ models:
   dbt_utils_integration_tests:
     cross_db_utils:
       +enabled: true
+      test_dateadd: &disabled
+        +enabled: false
+      test_datediff: *disabled
+      test_hash: *disabled
+      test_last_day: *disabled
     datetime:
       +enabled: true
-      test_date_spine: &disabled
-        +enabled: false
+      test_date_spine: *disabled
     materializations: *disabled
       
     schema_tests:
-      +enabled: false
+      # +enabled: false
+      data_test_mutually_exclusive_ranges_no_gaps: *disabled
+      data_test_mutually_exclusive_ranges_with_gaps: *disabled
+      data_test_not_constant: *disabled
+      data_test_relationships_where_table_2: *disabled
+      data_test_unique_where: *disabled
+      data_test_not_null_where: *disabled
     sql:
       +enabled: true
       test_generate_series: *disabled
@@ -38,6 +48,9 @@ models:
       test_get_relations_by_pattern: *disabled
       test_get_relations_by_prefix_and_union: *disabled
       test_groupby: *disabled
+      get_query_results_as_dict: *disabled
+      test_surrogate_key: *disabled
+      test_union: *disabled
     web:
       +enabled: false
 

--- a/integration_tests/dbt_utils/packages.yml
+++ b/integration_tests/dbt_utils/packages.yml
@@ -1,0 +1,5 @@
+
+packages:
+  - local: ../../
+  - local: ../../dbt-utils
+  - local: ../../dbt-utils/integration_tests

--- a/macros/dbt_utils/cross_db_utils/hash.sql
+++ b/macros/dbt_utils/cross_db_utils/hash.sql
@@ -1,0 +1,17 @@
+{% macro sqlserver__hash(field) %}
+    hashbytes('md5', field)
+{% endmacro %}
+
+
+{#
+    Imagine an adapter plugin, dbt-synapse, that inherits from dbt-sqlserver.
+    For the time being, we need to explicitly reimplement sqlserver__ macros
+    as synapse__ macros.
+    
+    TODO: We can make a small change to dbt-core (https://github.com/fishtown-analytics/dbt/issues/2923)
+    that will make the inheritance of dispatched macros work just like the 
+    inheritance of other adapter objects, and render the following code redundant.
+#}
+{% macro synapse__hash(field) %}
+    {% do return(sqlserver__hash(field)) %}
+{% endmacro %}

--- a/macros/dbt_utils/cross_db_utils/length.sql
+++ b/macros/dbt_utils/cross_db_utils/length.sql
@@ -1,0 +1,7 @@
+{% macro sqlserver__length(expression) %}
+
+    len(
+        {{ expression }}
+    )
+    
+{%- endmacro -%}

--- a/macros/dbt_utils/cross_db_utils/split_part.sql
+++ b/macros/dbt_utils/cross_db_utils/split_part.sql
@@ -1,0 +1,23 @@
+{% macro sqlserver__split_part(string_text, delimiter_text, part_number) %}
+
+    split_part(
+        {{ delimiter_text }},
+        {{ string_text }},
+        {{ part_number }}
+        )
+
+{% endmacro %}
+
+
+{#
+    Imagine an adapter plugin, dbt-synapse, that inherits from dbt-sqlserver.
+    For the time being, we need to explicitly reimplement sqlserver__ macros
+    as synapse__ macros.
+    
+    TODO: We can make a small change to dbt-core (https://github.com/fishtown-analytics/dbt/issues/2923)
+    that will make the inheritance of dispatched macros work just like the 
+    inheritance of other adapter objects, and render the following code redundant.
+#}
+{% macro synapse__split_part(string_text, delimiter_text, part_number) %}
+    {% do return(sqlserver__split_part(string_text, delimiter_text, part_number)) %}
+{% endmacro %}

--- a/macros/dbt_utils/cross_db_utils/width_bucket.sql
+++ b/macros/dbt_utils/cross_db_utils/width_bucket.sql
@@ -18,10 +18,9 @@
     {%- set ceil_val -%}
     CEILING(({{ expr }} - {{ min_value }})/{{ bin_size }})
     {%- endset %}
-    IIF(
-          {{ ceil_val }} > {{ num_buckets }} + 1
-        , {{ num_buckets }} + 1
-        , {{ ceil_val }}
-    )
+    (case when {{ ceil_val }} > ({{ num_buckets }} + 1)
+        then {{ num_buckets }} + 1
+        else {{ ceil_val }}
+    end)
    
 {%- endmacro %}

--- a/macros/dbt_utils/cross_db_utils/width_bucket.sql
+++ b/macros/dbt_utils/cross_db_utils/width_bucket.sql
@@ -15,11 +15,13 @@
         end
     ) +
       -- Anything over max_value goes the N+1 bucket
+    {%- set ceil_val -%}
+    CEILING(({{ expr }} - {{ min_value }})/{{ bin_size }})
+    {%- endset %}
     IIF(
-    	  CEILING(({{ expr }} - {{ min_value }})/{{ bin_size }})
-          > {{ num_buckets }} + 1
+          {{ ceil_val }} > {{ num_buckets }} + 1
         , {{ num_buckets }} + 1
-        , CEILING(({{ expr }} - {{ min_value }})/{{ bin_size }})
+        , {{ ceil_val }}
     )
    
 {%- endmacro %}

--- a/macros/dbt_utils/schema_tests/at_least_one.sql
+++ b/macros/dbt_utils/schema_tests/at_least_one.sql
@@ -1,0 +1,18 @@
+{% macro test_at_least_one(model) %}
+
+{% set column_name = kwargs.get('column_name', kwargs.get('arg')) %}
+
+select count(*)
+from (
+    select
+        {# subquery aggregate columns need aliases #}
+        {# thus: 'unique_values' #}
+      count({{ column_name }}) as unique_values
+
+    from {{ model }}
+
+    having count({{ column_name }}) = 0
+
+) validation_errors
+
+{% endmacro %}

--- a/macros/dbt_utils/schema_tests/cardinality_equality.sql
+++ b/macros/dbt_utils/schema_tests/cardinality_equality.sql
@@ -1,0 +1,50 @@
+{% macro test_cardinality_equality(model, to, field) %}
+{# T-SQL doesn't let you use numbers as aliases for columns #}
+{# Thus, no "GROUP BY 1" #}
+{% set column_name = kwargs.get('column_name', kwargs.get('from')) %}
+
+
+with table_a as (
+select
+  {{ column_name }},
+  count(*) as num_rows
+from {{ model }}
+group by {{ column_name }}
+),
+
+table_b as (
+select
+  {{ field }},
+  count(*) as num_rows
+from {{ to }}
+group by {{ column_name }}
+),
+
+except_a as (
+  select *
+  from table_a
+  {{ dbt_utils.except() }}
+  select *
+  from table_b
+),
+
+except_b as (
+  select *
+  from table_b
+  {{ dbt_utils.except() }}
+  select *
+  from table_a
+),
+
+unioned as (
+  select *
+  from except_a
+  union all
+  select *
+  from except_b
+)
+
+select count(*)
+from unioned
+
+{% endmacro %}

--- a/macros/dbt_utils/schema_tests/expression_is_true.sql
+++ b/macros/dbt_utils/schema_tests/expression_is_true.sql
@@ -1,0 +1,23 @@
+{% macro test_expression_is_true(model, condition='1=1') %}
+{# T-SQL has no boolean data type so we use 1=1 which returns TRUE #}
+{# ref https://stackoverflow.com/a/7170753/3842610 #}
+{% set expression = kwargs.get('expression', kwargs.get('arg')) %}
+
+with meet_condition as (
+
+    select * from {{ model }} where {{ condition }}
+
+),
+validation_errors as (
+
+    select
+        *
+    from meet_condition
+    where not({{expression}})
+
+)
+
+select count(*)
+from validation_errors
+
+{% endmacro %}

--- a/macros/dbt_utils/schema_tests/not_constant.sql
+++ b/macros/dbt_utils/schema_tests/not_constant.sql
@@ -1,0 +1,20 @@
+
+{% macro test_not_constant(model) %}
+
+{% set column_name = kwargs.get('column_name', kwargs.get('arg')) %}
+
+select count(*)
+
+from (
+
+    select
+          count(distinct {{ column_name }}) as filler_column
+
+    from {{ model }}
+
+    having count(distinct {{ column_name }}) = 1
+
+    ) validation_errors
+
+
+{% endmacro %}


### PR DESCRIPTION
## goals

the purpose of this PR is to get a baseline set of macros working. there are many still missing, but at least now we have coverage for a few of them. one problem is the way that `dbt-utils` tests macros is by using schema tests defined within `dbt-utils`. So next up is to open a PR in `dbt-utils` to make the schema tests dispatchable.

I'm going to open an example PR shortly that shows how we can incrementally add support for more dbt-utils while also ensuring we're testing that it works.

## still to do but now out of scope for this PR

### Incorrect syntax near...
  - `::`
    - [x] `cross_db_utils/current_timestamp.sql`
    - [x] `cross_db_utils/current_timestamp_in_utc.sql`
  - the keyword `with`
    - [ ] `sql/generate_series.sql`
    - [ ] `datetime/date_spine.sql`
  - `-`
    - [ ] `sql/get_relations_by_pattern.sql`
    - [ ] `sql/get_relations_by_prefix_and_union.sql`
  - [ ] `string_text` in `cross_db_utils/position.sql`
### `function` is not a recognized built-in function name
  - `date_trunc`
    - [ ] `cross_db_utils/date_trunc.sql`
    - [ ] `cross_db_utils/last_day.sql`
  - [ ] `split_part` in `cross_db_utils/split_part.sql`
  - [ ] `mod` in `cross_db_utils/width_bucket.sql`
  - [x] `length` in `cross_db_utils/length.sql`
### MISC
- Each GROUP BY expression must contain at least one column that is not an outer reference
  - [ ] `sql/get_column_values.sql`
  - [ ] `sql/groupby.sql`
- Invalid column name `'field'`
  - [x] `cross_db_utils/hash.sql`
  - [x] `sql/surrogate_key.sql`