### PR TITLE
Add support for bigger varchar field in surrogate key

### DIFF
--- a/macros/dbt_utils/sql/surrogate_key.sql
+++ b/macros/dbt_utils/sql/surrogate_key.sql
@@ -1,0 +1,44 @@
+{%- macro sqlserver__surrogate_key(field_list) -%}
+
+{%- if varargs|length >= 1 or field_list is string %}
+
+{%- set error_message = '
+Warning: the `surrogate_key` macro now takes a single list argument instead of \
+multiple string arguments. Support for multiple string arguments will be \
+deprecated in a future release of dbt-utils. The {}.{} model triggered this warning. \
+'.format(model.package_name, model.name) -%}
+
+{%- do exceptions.warn(error_message) -%}
+
+{# first argument is not included in varargs, so add first element to field_list_xf #}
+{%- set field_list_xf = [field_list] -%}
+
+{%- for field in varargs %}
+{%- set _ = field_list_xf.append(field) -%}
+{%- endfor -%}
+
+{%- else -%}
+
+{# if using list, just set field_list_xf as field_list #}
+{%- set field_list_xf = field_list -%}
+
+{%- endif -%}
+
+
+{%- set fields = [] -%}
+
+{%- for field in field_list_xf -%}
+
+    {%- set _ = fields.append(
+        "coalesce(cast(" ~ field ~ " as varchar(max)), '')"
+    ) -%}
+
+    {%- if not loop.last %}
+        {%- set _ = fields.append("'-'") -%}
+    {%- endif -%}
+
+{%- endfor -%}
+
+{{dbt_utils.hash(dbt_utils.concat(fields))}}
+
+{%- endmacro -%}


### PR DESCRIPTION
Changed line 33 to allow for bigger varchar fields.
**Original**:

cast(" ~ field ~ " as " ~ dbt_utils.string() ~ ")

which translates to 

CAST( {{ field }} AS varchar(30))

**New**

CAST( {{ field }} AS varchar(max))