### PR TITLE
Manually specify varchar length to max length 

### DIFF
--- a/macros/dbt_utils/cross_db_utils/datatypes.sql
+++ b/macros/dbt_utils/cross_db_utils/datatypes.sql
@@ -1,5 +1,5 @@
 {%- macro sqlserver__type_string() -%}
-    VARCHAR
+    VARCHAR(900)
 {%- endmacro -%}
 
 {#


### PR DESCRIPTION
allowed whilst still enabling indexes. Maybe  a tiny bit less performant than default (30) but much more flexible.

This is a competing PR to #14 . 

Hopefully it enables the same functionality gain with less code. 