### PR TITLE
referenced sql server macros for synapse

### DIFF
--- a/macros/dbt_utils/cross_db_utils/concat.sql
+++ b/macros/dbt_utils/cross_db_utils/concat.sql
@@ -1,3 +1,7 @@
 {% macro sqlserver__concat(fields) -%}
     concat({{ fields|join(', ') }}, '')
 {%- endmacro %}
+
+{% macro synapse__concat(fields) -%}
+    {% do return(sqlserver__concat(fields)) %}
+{%- endmacro %}

--- a/macros/dbt_utils/cross_db_utils/current_timestamp.sql
+++ b/macros/dbt_utils/cross_db_utils/current_timestamp.sql
@@ -2,6 +2,14 @@
     getdate()
 {% endmacro %}
 
+{% macro synapse__current_timestamp() %}
+    {% do return(sqlserver__current_timestamp()) %}
+{% endmacro %}
+
 {% macro sqlserver__current_timestamp_in_utc() %}
     getutcdate()
+{% endmacro %}
+
+{% macro synapse__current_timestamp_in_utc() %}
+    {% do return(sqlserver__current_timestamp_in_utc()) %}
 {% endmacro %}

--- a/macros/dbt_utils/cross_db_utils/date_trunc.sql
+++ b/macros/dbt_utils/cross_db_utils/date_trunc.sql
@@ -1,3 +1,7 @@
 {% macro sqlserver__date_trunc(datepart, date) %}
     CAST(DATEADD({{datepart}}, DATEDIFF({{datepart}}, 0, {{date}}), 0) AS DATE)
 {% endmacro %}
+
+{% macro synapse__date_trunc(datepart, date) %}
+    {% do return(sqlserver__date_trunc(datepart, date)) %}
+{% endmacro %}

--- a/macros/dbt_utils/cross_db_utils/last_day.sql
+++ b/macros/dbt_utils/cross_db_utils/last_day.sql
@@ -11,3 +11,7 @@
     {%- endif -%}
 
 {%- endmacro %}
+
+{% macro synapse__last_day(date, datepart) -%}
+    {% do return(sqlserver__last_day(date, datepart)) %}
+{%- endmacro %}

--- a/macros/dbt_utils/cross_db_utils/length.sql
+++ b/macros/dbt_utils/cross_db_utils/length.sql
@@ -3,3 +3,7 @@
     len( {{ expression }} )
 
 {%- endmacro -%}
+
+{% macro synapse__length(expression) %}
+    {% do return(sqlserver__length(expression)) %}
+{%- endmacro -%}

--- a/macros/dbt_utils/cross_db_utils/position.sql
+++ b/macros/dbt_utils/cross_db_utils/position.sql
@@ -6,3 +6,7 @@
     )
     
 {%- endmacro -%}
+
+{% macro synapse__position(substring_text, string_text) %}
+    {% do return(sqlserver__position(substring_text, string_text)) %}
+{%- endmacro -%}

--- a/macros/dbt_utils/cross_db_utils/safe_cast.sql
+++ b/macros/dbt_utils/cross_db_utils/safe_cast.sql
@@ -1,3 +1,7 @@
 {% macro sqlserver__safe_cast(field, type) %}
     try_cast({{field}} as {{type}})
 {% endmacro %}
+
+{% macro synapse__safe_cast(field, type) %}
+    {% do return(sqlserver__safe_cast(field, type)) %}
+{% endmacro %}

--- a/macros/dbt_utils/cross_db_utils/width_bucket.sql
+++ b/macros/dbt_utils/cross_db_utils/width_bucket.sql
@@ -24,3 +24,7 @@
     end)
    
 {%- endmacro %}
+
+{% macro synapse__width_bucket(expr, min_value, max_value, num_buckets) -%}
+    {% do return(sqlserver__width_bucket(expr, min_value, max_value, num_buckets)) %}
+{%- endmacro %}

--- a/macros/dbt_utils/schema_tests/at_least_one.sql
+++ b/macros/dbt_utils/schema_tests/at_least_one.sql
@@ -1,4 +1,4 @@
-{% macro test_at_least_one(model) %}
+{% macro sqlserver__test_at_least_one(model) %}
 
 {% set column_name = kwargs.get('column_name', kwargs.get('arg')) %}
 
@@ -15,4 +15,8 @@ from (
 
 ) validation_errors
 
+{% endmacro %}
+
+{% macro synapse__test_at_least_one(model) %}
+    {% do return(sqlserver__test_at_least_one(model)) %}
 {% endmacro %}

--- a/macros/dbt_utils/schema_tests/cardinality_equality.sql
+++ b/macros/dbt_utils/schema_tests/cardinality_equality.sql
@@ -1,4 +1,4 @@
-{% macro test_cardinality_equality(model, to, field) %}
+{% macro sqlserver__test_cardinality_equality(model, to, field) %}
 {# T-SQL doesn't let you use numbers as aliases for columns #}
 {# Thus, no "GROUP BY 1" #}
 {% set column_name = kwargs.get('column_name', kwargs.get('from')) %}
@@ -47,4 +47,8 @@ unioned as (
 select count(*)
 from unioned
 
+{% endmacro %}
+
+{% macro synapse__test_cardinality_equality(model, to, field) %}
+    {% do return(sqlserver__test_cardinality_equality(model, to, field)) %}
 {% endmacro %}

--- a/macros/dbt_utils/schema_tests/expression_is_true.sql
+++ b/macros/dbt_utils/schema_tests/expression_is_true.sql
@@ -1,4 +1,4 @@
-{% macro test_expression_is_true(model, condition='1=1') %}
+{% macro sqlserver__test_expression_is_true(model, condition='1=1') %}
 {# T-SQL has no boolean data type so we use 1=1 which returns TRUE #}
 {# ref https://stackoverflow.com/a/7170753/3842610 #}
 {% set expression = kwargs.get('expression', kwargs.get('arg')) %}
@@ -20,4 +20,8 @@ validation_errors as (
 select count(*)
 from validation_errors
 
+{% endmacro %}
+
+{% macro synapse__test_expression_is_true(model, condition='1=1') %}
+    {% do return(sqlserver__test_expression_is_true(model, condition='1=1')) %}
 {% endmacro %}

--- a/macros/dbt_utils/schema_tests/not_constant.sql
+++ b/macros/dbt_utils/schema_tests/not_constant.sql
@@ -1,5 +1,5 @@
 
-{% macro test_not_constant(model) %}
+{% macro sqlserver__test_not_constant(model) %}
 
 {% set column_name = kwargs.get('column_name', kwargs.get('arg')) %}
 
@@ -17,4 +17,8 @@ from (
     ) validation_errors
 
 
+{% endmacro %}
+
+{% macro synapse__test_not_constant(model) %}
+    {% do return(sqlserver__test_not_constant(model)) %}
 {% endmacro %}


### PR DESCRIPTION
This PR lessens the macro dependency of `synapse` on `sqlserver`. In this change, new macros were created for `synapse` that references the `sqlserver` macros. This simplifies the process of future macro editing in that the change can happen once in the code base rather than in multiple areas of the code base.

Note: this PR must be completed after the completion of the following PR (https://github.com/fishtown-analytics/dbt-utils/pull/312)