### PR TITLE
Fix  the macro when the datepart  = hour

### DIFF
--- a/macros/dbt_utils/datetime/date_spine.sql
+++ b/macros/dbt_utils/datetime/date_spine.sql
@@ -54,7 +54,7 @@
 
     rawdata as (
 
-        select top ({{dbt_utils.datediff(start_date, end_date, datepart)}}) rownum -1 as n
+        select top ({{dbt_utils.datediff(start_date, dbt_utils.dateadd('day',1,end_date), datepart)}}) rownum -1 as n
         from nums
         order by rownum
     ),


### PR DESCRIPTION
With a `datepart` smaller than day, the `datediff` in the `top` was comparing `datetime` to `date` (i.e. `datetime` at the first minute of the day), not selecting enough records for populating the last day. 

This update selects enough values in the` top` by looking at the next day. Additional values are still filtered out below in the macro, in the "filtered" CTE.