### PR TITLE
Add macro for dateadd, casting to datetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+
+## `0.6.6`
+
+- fix for `dateadd()` macro when adding intervals smaller than a day [#35](https://github.com/dbt-msft/tsql-utils/pull/35) thanks [@b-per](https://github.com/b-per)!
+## `0.6.5`
+
+- syntactical update, because four-part version numbers aren't canonically SemVer.
 ## `0.6.4.1`
 
 ### Added

--- a/macros/dbt_utils/cross_db_utils/dateadd.sql
+++ b/macros/dbt_utils/cross_db_utils/dateadd.sql
@@ -1,0 +1,9 @@
+{% macro sqlserver__dateadd(datepart, interval, from_date_or_timestamp) %}
+
+    dateadd(
+        {{ datepart }},
+        {{ interval }},
+        cast({{ from_date_or_timestamp }} as datetime)
+        )
+
+{% endmacro %}


### PR DESCRIPTION
Without casting, a SQL error is raised when we add intervals smaller than the day.
The same casting has been made in the BigQuery version of the macro.