### PR TITLE
Shim dbt-expectations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,9 @@ jobs:
             dbt run --target azuresql --full-refresh
             dbt test --target azuresql
       - store_artifacts:
-          path: ./logs
+          path: /root/project/integration_tests/dbt_expectations/logs/dbt.log
+      - store_artifacts:
+          path: /root/project/integration_tests/dbt_expectations/target
 
   integration-dbt-utils-synapse:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,23 +56,6 @@ jobs:
       - run: *pull-submodules
       - run: *setup-dbt
       - run:
-          name: "debug"
-          # TODO re-implement dbt-utils's data tests
-          command: |
-            . venv/bin/activate
-            cd integration_tests/dbt_expectations
-            echo "local folder"
-            pwd
-            ls
-            cd ..
-            echo "integration_tests folder"
-            pwd
-            ls
-            cd ..
-            echo "tsql-utils folder"
-            pwd
-            ls
-      - run:
           name: "Run Tests - dbt-expectations"
           # TODO port core dbt-expectations test logic
           # TODO re-implement dbt-utils's data tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,13 +74,14 @@ jobs:
             ls
       - run:
           name: "Run Tests - dbt-expectations"
+          # TODO port core dbt-expectations test logic
           # TODO re-implement dbt-utils's data tests
           command: |
             . venv/bin/activate
             cd integration_tests/dbt_expectations
             dbt deps --target azuresql
             dbt run --target azuresql --full-refresh
-            dbt test --target azuresql
+            # dbt test --target azuresql
       - store_artifacts:
           path: /root/project/integration_tests/dbt_expectations/logs/dbt.log
       - store_artifacts:
@@ -127,13 +128,14 @@ jobs:
       - run: *setup-dbt
       - run: *start-synapse
       - run:
+          # TODO port core dbt-expectations test logic
           name: "Run Tests - dbt-expectations"
           command: |
             . venv/bin/activate
             cd integration_tests/dbt_expectations
             dbt deps --target synapse
             dbt run --target synapse --full-refresh
-            dbt test --target synapse
+            # dbt test --target synapse
       - run: *pause-synapse
       - store_artifacts:
           path: ./logs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,9 +72,6 @@ jobs:
             echo "tsql-utils folder"
             pwd
             ls
-      - store_artifacts:
-          path: ./integration_tests/dbt_expectations/logs
-
       - run:
           name: "Run Tests - dbt-expectations"
           # TODO re-implement dbt-utils's data tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
       - run: *setup-dbt
       - run: &start-synapse
           name: resume Synapse pool/db
-          command: az synapse sql pool resume --name $DBT_SYNAPSE_DB --workspace-name $DBT_SYNAPSE_SERVER --resource-group dbt-msf
+          command: az synapse sql pool resume --name $DBT_SYNAPSE_DB --workspace-name $DBT_SYNAPSE_SERVER --resource-group dbt-msft
       - run:
           name: "Run Tests - dbt-utils"
           # TODO: data test is faailing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,17 @@ jobs:
             dbt seed --target azuresql --full-refresh
             dbt run --target azuresql --full-refresh
             dbt test --target azuresql --schema --exclude data_test_unique_where data_test_not_null_where data_test_mutually_exclusive_ranges_no_gaps data_test_mutually_exclusive_ranges_with_gaps data_test_relationships_where_table_2 test_urls test_url_host test_url_path data_test_at_least_one data_people data_test_expression_is_true data_test_not_constant
+
+      - run:
+          name: "Run Tests - dbt-expectations"
+          # TODO re-implement dbt-utils's data tests
+          command: |
+            . venv/bin/activate
+            cd integration_tests/dbt_expectations
+            dbt deps --target azuresql
+            dbt seed --target azuresql --full-refresh
+            dbt run --target azuresql --full-refresh
+            dbt test --target azuresql
       
       - store_artifacts:
           path: ./logs
@@ -74,7 +85,17 @@ jobs:
             dbt seed --target synapse --full-refresh
             dbt run --target synapse --full-refresh
             dbt test --target synapse --schema --exclude data_test_unique_where data_test_not_null_where data_test_mutually_exclusive_ranges_no_gaps data_test_mutually_exclusive_ranges_with_gaps data_test_relationships_where_table_2 test_urls test_url_host test_url_path data_test_at_least_one data_people data_test_expression_is_true data_test_not_constant
-      
+
+      - run:
+          name: "Run Tests - dbt-expectations"
+          # TODO re-implement dbt-utils's data tests
+          command: |
+            . venv/bin/activate
+            cd integration_tests/dbt_expectations
+            dbt deps --target azuresql
+            dbt seed --target azuresql --full-refresh
+            dbt run --target azuresql --full-refresh
+            dbt test --target azuresql
       - store_artifacts:
           path: ./logs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install --upgrade pip setuptools
-            pip install dbt-sqlserver
+            pip install dbt-synapse
             mkdir -p ~/.dbt
             cp integration_tests/ci/sample.profiles.yml ~/.dbt/profiles.yml
       
@@ -45,6 +45,28 @@ jobs:
 
       - store_artifacts:
           path: ./logs
+
+  integration-dbt-expectations-azuresql:
+    docker:
+      - image: dbtmsft/msodbc_py:0.5
+    steps:
+      - checkout
+      - azure-cli/install
+      - azure-cli/login-with-service-principal: *azure-creds
+      - run: *pull-submodules
+      - run: *setup-dbt
+      - run:
+          name: "Run Tests - dbt-expectations"
+          # TODO re-implement dbt-utils's data tests
+          command: |
+            . venv/bin/activate
+            cd integration_tests/dbt_expectations
+            dbt deps --target azuresql
+            dbt run --target azuresql --full-refresh
+            dbt test --target azuresql
+      - store_artifacts:
+          path: ./logs
+
   integration-dbt-utils-synapse:
     docker:
       - image: dbtmsft/msodbc_py:0.5
@@ -53,18 +75,10 @@ jobs:
       - run: *pull-submodules
       - azure-cli/install
       - azure-cli/login-with-service-principal: *azure-creds
-      - run:
+      - run: *setup-dbt
+      - run: &start-synapse
           name: resume Synapse pool/db
-          command: az synapse sql pool resume --name $DBT_SYNAPSE_DB --workspace-name $DBT_SYNAPSE_SERVER --resource-group dbt-msft
-      - run:
-          name: "Setup dbt"
-          command: |
-            python3 -m venv venv
-            . venv/bin/activate
-            pip install --upgrade pip setuptools
-            pip install dbt-synapse
-            mkdir -p ~/.dbt
-            cp integration_tests/ci/sample.profiles.yml ~/.dbt/profiles.yml
+          command: az synapse sql pool resume --name $DBT_SYNAPSE_DB --workspace-name $DBT_SYNAPSE_SERVER --resource-group dbt-msf
       - run:
           name: "Run Tests - dbt-utils"
           # TODO: data test is faailing
@@ -76,9 +90,31 @@ jobs:
             dbt seed --target synapse --full-refresh
             dbt run --target synapse --full-refresh
             dbt test --target synapse --schema
-      - run:
+      - run: &pause-synapse
           name: pause Synapse pool/db
           command: az synapse sql pool resume --name $DBT_SYNAPSE_DB --workspace-name $DBT_SYNAPSE_SERVER --resource-group dbt-msft
+      - store_artifacts:
+          path: ./logs
+
+  integration-dbt-expectations-synapse:
+    docker:
+      - image: dbtmsft/msodbc_py:0.5
+    steps:
+      - checkout
+      - run: *pull-submodules
+      - azure-cli/install
+      - azure-cli/login-with-service-principal: *azure-creds
+      - run: *setup-dbt
+      - run: *start-synapse
+      - run:
+          name: "Run Tests - dbt-expectations"
+          command: |
+            . venv/bin/activate
+            cd integration_tests/dbt_expectations
+            dbt deps --target synapse
+            dbt run --target synapse --full-refresh
+            dbt test --target synapse
+      - run: *pause-synapse
       - store_artifacts:
           path: ./logs
 
@@ -90,3 +126,5 @@ workflows:
       - integration-dbt-utils-azuresql: &dbt-context
           context: DBT_SYNAPSE_PROFILE
       - integration-dbt-utils-synapse: *dbt-context
+      - integration-dbt-expectations-azuresql: *dbt-context
+      - integration-dbt-expectations-synapse: *dbt-context

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,25 @@ jobs:
       - run: *pull-submodules
       - run: *setup-dbt
       - run:
+          name: "debug"
+          # TODO re-implement dbt-utils's data tests
+          command: |
+            . venv/bin/activate
+            cd integration_tests/dbt_expectations
+            echo "local folder"
+            pwd
+            ls
+            cd ..
+            echo "integration_tests folder"
+            pwd
+            ls
+            cd ..
+            echo "tsql-utils folder"
+            pwd
+            ls
+      - store_artifacts:
+          path: ./logs
+      - run:
           name: "Run Tests - dbt-expectations"
           # TODO re-implement dbt-utils's data tests
           command: |
@@ -124,8 +143,8 @@ workflows:
   version: 2
   test-all:
     jobs:
-      - integration-dbt-utils-azuresql: &dbt-context
+      - integration-dbt-expectations-azuresql: &dbt-context
           context: DBT_SYNAPSE_PROFILE
-      - integration-dbt-utils-synapse: *dbt-context
-      - integration-dbt-expectations-azuresql: *dbt-context
-      - integration-dbt-expectations-synapse: *dbt-context
+      # - integration-dbt-utils-azuresql: *dbt-context
+      # - integration-dbt-utils-synapse: *dbt-context
+      # - integration-dbt-expectations-synapse: *dbt-context

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,6 @@ workflows:
     jobs:
       - integration-dbt-expectations-azuresql: &dbt-context
           context: DBT_SYNAPSE_PROFILE
-      # - integration-dbt-utils-azuresql: *dbt-context
-      # - integration-dbt-utils-synapse: *dbt-context
-      # - integration-dbt-expectations-synapse: *dbt-context
+      - integration-dbt-utils-azuresql: *dbt-context
+      - integration-dbt-utils-synapse: *dbt-context
+      - integration-dbt-expectations-synapse: *dbt-context

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,7 @@ jobs:
       - run: &pause-synapse
           name: pause Synapse pool/db
           command: az synapse sql pool resume --name $DBT_SYNAPSE_DB --workspace-name $DBT_SYNAPSE_SERVER --resource-group dbt-msft
+          when: always
       - store_artifacts:
           path: ./logs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,8 @@ jobs:
             pwd
             ls
       - store_artifacts:
-          path: ./logs
+          path: ./integration_tests/dbt_expectations/logs
+
       - run:
           name: "Run Tests - dbt-expectations"
           # TODO re-implement dbt-utils's data tests

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,5 +4,5 @@
 	branch = master
 [submodule "dbt-expectations"]
 	path = dbt-expectations
-	url = https://github.com/swanderz/dbt-expectations
-	branch = compat_integration
+	url = https://github.com/calogica/dbt-expectations
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,5 @@
 	branch = master
 [submodule "dbt-expectations"]
 	path = dbt-expectations
-	url = https://github.com/calogica/dbt-expectations
+	url = https://github.com/swanderz/dbt-expectations
+	branch = compat_integration

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = dbt-utils
 	url = https://github.com/fishtown-analytics/dbt-utils
 	branch = master
+[submodule "dbt-expectations"]
+	path = dbt-expectations
+	url = https://github.com/calogica/dbt-expectations

--- a/integration_tests/ci/sample.profiles.yml
+++ b/integration_tests/ci/sample.profiles.yml
@@ -18,9 +18,7 @@ integration_tests:
       database: "{{ env_var('DBT_SYNAPSE_DB') }}"
       authentication: CLI
       schema: tsql_utils_integration_tests_synapse
-      encrypt: yes
-      trust_cert: yes
-      threads: 1
+      threads: 4
     azuresql:
       type: sqlserver
       driver: "ODBC Driver 17 for SQL Server"
@@ -30,6 +28,4 @@ integration_tests:
       username: "{{ env_var('DBT_AZURESQL_UID') }}"
       password: "{{ env_var('DBT_AZURESQL_PWD') }}"
       schema: tsql_utils_integration_tests_azuresql
-      encrypt: yes
-      trust_cert: yes
-      threads: 1
+      threads: 4

--- a/integration_tests/dbt_expectations/dbt_project.yml
+++ b/integration_tests/dbt_expectations/dbt_project.yml
@@ -1,0 +1,28 @@
+
+name: 'tsql_utils_dbt_expectations_integration_tests'
+version: '1.0'
+config-version: 2
+
+profile: 'integration_tests'
+
+source-paths: ["models"]
+analysis-paths: ["analysis"] 
+test-paths: ["tests"]
+data-paths: ["data"]
+macro-paths: ["macros"]
+
+target-path: "target"  # directory which will store compiled SQL files
+clean-targets:         # directories to be removed by `dbt clean`
+    - "target"
+    - "dbt_modules"
+    
+vars:
+  dbt_utils_dispatch_list: ['tsql_utils']
+  dbt_expectations_dispatch_list: ['tsql_utils']
+  dbt_date_dispatch_list: ['tsql_utils']
+  'dbt_date:time_zone': 'Pacific Standard Time'
+
+models:
+  dbt_expectations_integration_tests:
+    data_test_factored:
+      +materialized: table

--- a/integration_tests/dbt_expectations/dbt_project.yml
+++ b/integration_tests/dbt_expectations/dbt_project.yml
@@ -6,7 +6,7 @@ config-version: 2
 profile: 'integration_tests'
 
 source-paths: ["models"]
-analysis-paths: ["analysis"] 
+analysis-paths: ["analysis"]
 test-paths: ["tests"]
 data-paths: ["data"]
 macro-paths: ["macros"]
@@ -15,7 +15,7 @@ target-path: "target"  # directory which will store compiled SQL files
 clean-targets:         # directories to be removed by `dbt clean`
     - "target"
     - "dbt_modules"
-    
+
 vars:
   dbt_utils_dispatch_list: ['tsql_utils']
   dbt_expectations_dispatch_list: ['tsql_utils']

--- a/integration_tests/dbt_expectations/packages.yml
+++ b/integration_tests/dbt_expectations/packages.yml
@@ -2,5 +2,4 @@
 packages:
   - local: ../../../tsql-utils # tsql_utils empty tho
   - local: ../../dbt-expectations # actual dbt-expectations package as submodule
-  - local: ../../dbt-utils # actual dbt-utils package as submodule
   - local: ../../dbt-expectations/integration_tests # nothing here for now

--- a/integration_tests/dbt_expectations/packages.yml
+++ b/integration_tests/dbt_expectations/packages.yml
@@ -1,5 +1,5 @@
 
 packages:
-  - local: ../../../tsql-utils # tsql_utils empty tho
+  - local: ../../../ # tsql_utils main macros
   - local: ../../dbt-expectations # actual dbt-expectations package as submodule
   - local: ../../dbt-expectations/integration_tests # nothing here for now

--- a/integration_tests/dbt_expectations/packages.yml
+++ b/integration_tests/dbt_expectations/packages.yml
@@ -1,0 +1,6 @@
+
+packages:
+  - local: ../../../tsql-utils # tsql_utils empty tho
+  - local: ../../dbt-expectations # actual dbt-expectations package as submodule
+  - local: ../../dbt-utils # actual dbt-utils package as submodule
+  - local: ../../dbt-expectations/integration_tests # nothing here for now

--- a/integration_tests/dbt_expectations/packages.yml
+++ b/integration_tests/dbt_expectations/packages.yml
@@ -1,5 +1,5 @@
 
 packages:
-  - local: ../../../ # tsql_utils main macros
+  - local: ../../ # tsql_utils main macros
   - local: ../../dbt-expectations # actual dbt-expectations package as submodule
   - local: ../../dbt-expectations/integration_tests # nothing here for now

--- a/macros/dbt_date/convert_timezones.sql
+++ b/macros/dbt_date/convert_timezones.sql
@@ -3,6 +3,6 @@
 {%- endmacro -%}
 
 {% macro synapse__convert_timezone(column, target_tz, source_tz) -%}
-    {% do return( dbt_date.sqlserver__convert_timezone(column, target_tz, source_tz)) %}
+    {% do return( tsql_utils.sqlserver__convert_timezone(column, target_tz, source_tz)) %}
 {%- endmacro -%}
 

--- a/macros/dbt_date/convert_timezones.sql
+++ b/macros/dbt_date/convert_timezones.sql
@@ -1,0 +1,8 @@
+{% macro sqlserver__convert_timezone(column, target_tz, source_tz) -%}
+    CAST({{ column }} as {{ dbt_utils.type_timestamp() }}) AT TIME ZONE '{{ source_tz }}' AT TIME ZONE '{{ target_tz }}'
+{%- endmacro -%}
+
+{% macro synapse__convert_timezone(column, target_tz, source_tz) -%}
+    {% do return( dbt_date.sqlserver__convert_timezone(column, target_tz, source_tz)) %}
+{%- endmacro -%}
+

--- a/macros/dbt_expectations/math/log_natural.sql
+++ b/macros/dbt_expectations/math/log_natural.sql
@@ -6,5 +6,5 @@
 
 
 {% macro synapse__log_natural(x) -%}
-    {% do return( dbt_expectations.sqlserver__log_natural(x)) %}
+    {% do return( tsql_utils.sqlserver__log_natural(x)) %}
 {%- endmacro -%}

--- a/macros/dbt_expectations/math/log_natural.sql
+++ b/macros/dbt_expectations/math/log_natural.sql
@@ -1,0 +1,10 @@
+{% macro sqlserver__log_natural(x) %}
+
+    log({{ x }})
+
+{%- endmacro -%}
+
+
+{% macro synapse__log_natural(x) -%}
+    {% do return( dbt_expectations.sqlserver__log_natural(x)) %}
+{%- endmacro -%}

--- a/macros/dbt_expectations/schema_tests/_generalized/equal_expression.sql
+++ b/macros/dbt_expectations/schema_tests/_generalized/equal_expression.sql
@@ -1,0 +1,17 @@
+{%- macro sqlserver__get_select(model, expression, row_condition, group_by) %}
+    select
+        {% for g in group_by -%}
+            {{ g }} as col_{{ loop.index }},
+        {% endfor -%}
+        {{ expression }} as expression
+    from
+        {{ model }}
+    {%- if row_condition %}
+    where
+        {{ row_condition }}
+    {% endif %}
+    group by
+        {% for g in group_by -%}
+            {{ g }}{% if not loop.last %}, {% endif %}
+        {% endfor %}
+{% endmacro -%}

--- a/macros/dbt_utils/cross_db_utils/datatypes.sql
+++ b/macros/dbt_utils/cross_db_utils/datatypes.sql
@@ -1,11 +1,11 @@
-{%- macro sqlserver__type_string() -%}
+{% macro sqlserver__type_string() %}
     VARCHAR(900)
 {%- endmacro -%}
 
 -- TEMP UNTIL synapse is standalone adapter type
 {% macro sqlserver__type_timestamp() %}
-    {# Synapse does not support timestamp datatype see: #}
-    {# https://docs.microsoft.com/en-us/azure/synapse-analytics/sql-data-warehouse/sql-data-warehouse-tables-data-types#unsupported-data-types #}
+    {# in TSQL timestamp is really datetime #}
+    {# https://docs.microsoft.com/en-us/sql/t-sql/functions/date-and-time-data-types-and-functions-transact-sql?view=sql-server-ver15#DateandTimeDataTypes #}
     datetime
 {% endmacro %}
 
@@ -18,13 +18,10 @@
     that will make the inheritance of dispatched macros work just like the 
     inheritance of other adapter objects, and render the following code redundant.
 #}
-{% macro synapse__type_string(field) %}
+{% macro synapse__type_string() %}
     {% do return( tsql_utils.sqlserver__type_string()) %}
 {% endmacro %}
 
-
 {% macro synapse__type_timestamp() %}
-    {# Synapse does not support timestamp datatype see: #}
-    {# https://docs.microsoft.com/en-us/azure/synapse-analytics/sql-data-warehouse/sql-data-warehouse-tables-data-types#unsupported-data-types #}
-    datetime
+    {% do return( tsql_utils.sqlserver__type_timestamp()) %}
 {% endmacro %}

--- a/macros/dbt_utils/cross_db_utils/dateadd.sql
+++ b/macros/dbt_utils/cross_db_utils/dateadd.sql
@@ -7,3 +7,7 @@
         )
 
 {% endmacro %}
+
+{% macro synapse__dateadd(datepart, interval, from_date_or_timestamp) %}
+    {% do return( tsql_utils.sqlserver__dateadd(datepart, interval, from_date_or_timestamp)) %}
+{% endmacro %}

--- a/macros/dbt_utils/cross_db_utils/datediff.sql
+++ b/macros/dbt_utils/cross_db_utils/datediff.sql
@@ -1,13 +1,7 @@
-{% macro sqlserver__datediff(first_date, second_date, datepart) %}
-
+{% macro synapse__datediff(first_date, second_date, datepart) %}
     datediff(
         {{ datepart }},
         cast({{first_date}} as datetime),
         cast({{second_date}} as datetime)
         )
-
-{% endmacro %}
-
-{% macro synapse__datediff(first_date, second_date, datepart) %}
-    {% do return( tsql_utils.sqlserver__datediff(first_date, second_date, datepart)) %}
 {% endmacro %}

--- a/macros/dbt_utils/cross_db_utils/datediff.sql
+++ b/macros/dbt_utils/cross_db_utils/datediff.sql
@@ -1,0 +1,13 @@
+{% macro sqlserver__datediff(first_date, second_date, datepart) %}
+
+    datediff(
+        {{ datepart }},
+        cast({{first_date}} as datetime),
+        cast({{second_date}} as datetime)
+        )
+
+{% endmacro %}
+
+{% macro synapse__datediff(first_date, second_date, datepart) %}
+    {% do return( tsql_utils.sqlserver__datediff(first_date, second_date, datepart)) %}
+{% endmacro %}

--- a/macros/dbt_utils/sql/generate_series.sql
+++ b/macros/dbt_utils/sql/generate_series.sql
@@ -1,0 +1,37 @@
+{% macro sqlserver__generate_series(upper_bound) %}
+
+    {% set n = dbt_utils.get_powers_of_two(upper_bound) %}
+
+    with p as (
+        select 0 as generated_number union all select 1
+    ), unioned as (
+
+    select
+
+    {% for i in range(n) %}
+    p{{i}}.generated_number * power(2, {{i}})
+    {% if not loop.last %} + {% endif %}
+    {% endfor %}
+    + 1
+    as generated_number
+
+    from
+
+    {% for i in range(n) %}
+    p as p{{i}}
+    {% if not loop.last %} cross join {% endif %}
+    {% endfor %}
+
+    )
+
+    select *
+    from unioned
+    where generated_number <= {{upper_bound}}
+    {# in TSQL you can't have an order by in a view statement! #}
+    {# order by generated_number #}
+
+{% endmacro %}
+
+{% macro synapse__generate_series(upper_bound) %}
+    {% do return( tsql_utils.sqlserver__generate_series(upper_bound)) %}
+{% endmacro %}


### PR DESCRIPTION
thanks to @b-per's hard work properly dispatching the `dbt-expectations`, macros, the baseline infrastructure for shimming [calogica/dbt-expectations](https://github.com/calogica/dbt-expectations).  `deps` and `run` both work from the the `integration_tests/dbt_expectations` directory. In a future PR, someone (cough @b-per cough) can uncomment start working on getting `dbt-expectations`'s tests passing by shimming macros as needed.

In retrospect, `dbt-date` would have been an easier target to start with, but we'll tackle that in #39.

also some more dbt-utils macros are brought officially into the fold, namely:
- a bugfix for `sqlserver_type_string()` 
- `synapse__dateadd()`  as a dispatch of `sqlserver__datediff()`
- `synapse__datediff()` because `default__datediff()` works out of the box.
- `sqlserver__generate_series()` and `synapse__generate_series()`