### PR TITLE
disable new IntTest models

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,9 +31,11 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install --upgrade pip setuptools
-            pip install dbt-synapse
+            pip install git+https://github.com/dbt-msft/dbt-synapse.git#egg=dbt-synapse
             mkdir -p ~/.dbt
             cp integration_tests/ci/sample.profiles.yml ~/.dbt/profiles.yml
+            dbt --version
+            pip list | grep "dbt"
       
       - run:
           name: "Run Tests"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,16 +131,16 @@ workflows:
           context: DBT_SYNAPSE_PROFILE
       - integration-dbt-utils-azuresql: *dbt-context
       # - integration-dbt-expectations-azuresql: *dbt-context
-      # - integration-dbt-date-azuresql: *dbt-context
+      - integration-dbt-date-azuresql: *dbt-context
       - integration-dbt-utils-synapse: &syn-step
           <<: *dbt-context
           requires:
             - start-synapse
       # - integration-dbt-expectations-synapse: *syn-step
-      # - integration-dbt-date-synapse: *syn-step
+      - integration-dbt-date-synapse: *syn-step
       - pause-synapse:
           <<: *dbt-context
           requires:
             - integration-dbt-utils-synapse
             # - integration-dbt-expectations-synapse
-            # - integration-dbt-date-synapse
+            - integration-dbt-date-synapse

--- a/integration_tests/dbt_date/dbt_project.yml
+++ b/integration_tests/dbt_date/dbt_project.yml
@@ -31,6 +31,14 @@ models:
   dbt_date_integration_tests:
     +schema: dbt_date_integration_tests
     +materialized: table
-    +enabled: false
-    test_dates:
-      +enabled: true
+    # needed bc of 
+    # https://github.com/calogica/dbt-date/pull/30
+    # +enabled: false (THIS SHOULD WORK BUT DOESN'T!?)
+    # test_dates:
+    #   +enabled: true
+    dates: &disabled
+      +enabled: false
+    dim_week: *disabled
+    dim_date: *disabled
+    dim_date_fiscal: *disabled
+    dim_hour: *disabled

--- a/integration_tests/dbt_date/dbt_project.yml
+++ b/integration_tests/dbt_date/dbt_project.yml
@@ -31,3 +31,6 @@ models:
   dbt_date_integration_tests:
     +schema: dbt_date_integration_tests
     +materialized: table
+    +enabled: false
+    test_dates:
+      +enabled: true


### PR DESCRIPTION
temporarily disable the new models introduced by @clausherther in https://github.com/calogica/dbt-date/pull/30 because they use nested CTEs and ephemeral models