### PR TITLE
Add schema cleanup macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,35 @@ This package provides "shims" for:
 
 Wherever a custom tsql macro exists, dbt_utils adapter dispatch will pass to tsq_utils. This means you can just do `{{dbt_utils.hash('mycolumnname')}}` just like your friends with Snowflake. 
 
+### Cleanup Macros
+
+Some helper macros have been added to simplfy development database cleanup. Usage is as follows:
+
+Drop all schemas for each prefix with the provided prefix list (dev and myschema being a sample prefixes):
+```bash
+dbt run-operation sqlserver__drop_schemas_by_prefixes --args "{prefixes: ['dev', 'myschema']}"
+```
+
+Drop all schemas with the single provided prefix (dev being a sample prefix):
+```bash
+dbt run-operation sqlserver__drop_schemas_by_prefixes --args "{prefixes: myschema}"
+```
+
+Drop a schema with a specific name (myschema_seed being a sample schema name used in the project):
+```bash
+dbt run-operation sqlserver__drop_schema_by_name --args "{schema_name: myschema_seed}"
+```
+
+Drop any models that are no longer included in the project (dependent on the current target):
+```bash
+dbt run-operation sqlserver__drop_old_relations
+```
+or for a dry run to preview dropped models:
+```bash
+dbt run-operation sqlserver__drop_old_relations --args "{dry_run: true}"
+```
+
+
 
 ## Installation Instructions
 

--- a/macros/dbt_utils/schema_cleanup/drop_old_relations.sql
+++ b/macros/dbt_utils/schema_cleanup/drop_old_relations.sql
@@ -1,0 +1,57 @@
+-- Tidyed up version of Jacob Matson's contribution in the dbt-sqlserver slack channel https://app.slack.com/client/T0VLPD22H/CMRMDDQ9W/thread/CMRMDDQ9W-1625096967.079800 
+
+{% macro sqlserver__drop_old_relations(dry_run='false') %}
+    {% if execute %}
+        {% set current_models = [] %}
+        {% for node in graph.nodes.values()|selectattr("resource_type", "in", ["model", "seed", "snapshot"])%}
+            {% do current_models.append(node.name) %}
+        {% endfor %}
+    {% endif %}
+    {% set cleanup_query %}
+        with models_to_drop as (
+            select
+            case 
+                when table_type = 'BASE TABLE' then 'TABLE'
+                when table_type = 'VIEW' then 'VIEW'
+            end as relation_type,
+            CASE 
+                WHEN table_type = 'VIEW' THEN concat_ws('.', table_schema, table_name) 
+                    ELSE concat_ws('.', table_catalog, table_schema, table_name) 
+                END as relation_name
+            from
+                "{{ target.database }}".information_schema.tables -- Added quotes for any whitespace in target db
+            where
+                table_schema like '{{ target.schema }}%'
+                and table_name not in (
+                    {%- for model in current_models -%}
+                        '{{ model.upper() }}'
+                        {%- if not loop.last -%}
+                            ,
+                        {% endif %}
+                    {%- endfor -%})
+                )
+        select 
+            CONCAT( 'drop ' , relation_type , ' ' , relation_name , ';' ) as drop_commands
+        from 
+            models_to_drop
+        where
+            -- intentionally exclude unhandled table_types, including 'external table`
+            CONCAT( 'drop ' , relation_type , ' ' , relation_name , ';' ) is not null
+    {% endset %}
+
+    {% do log(cleanup_query, info=True) %}
+    {% set drop_commands = run_query(cleanup_query).columns[0].values() %}
+
+    {% do log('dry_run: ' + dry_run|string, info=True) %}
+
+    {% if drop_commands %}
+        {% for drop_command in drop_commands %}
+            {% do log(drop_command, info=True) %}
+            {% if dry_run == 'false' %}
+                {% do run_query(drop_command) %}
+            {% endif %}
+        {% endfor %}
+    {% else %}
+        {% do log('No relations to clean.', info=True) %}
+    {% endif %}
+{%- endmacro -%}

--- a/macros/dbt_utils/schema_cleanup/drop_schema_by_name.sql
+++ b/macros/dbt_utils/schema_cleanup/drop_schema_by_name.sql
@@ -1,0 +1,4 @@
+{% macro sqlserver__drop_schema_by_name(schema_name) %}
+    {% set relation = api.Relation.create(database=target.database, schema=schema_name) %}
+    {% do drop_schema(relation) %}
+{% endmacro %}

--- a/macros/dbt_utils/schema_cleanup/drop_schemas_by_prefixes.sql
+++ b/macros/dbt_utils/schema_cleanup/drop_schemas_by_prefixes.sql
@@ -1,0 +1,27 @@
+{% macro sqlserver__drop_schemas_by_prefixes(prefixes) %}
+    {# Ensure input is a list to iterate later #}
+    {% set prefix_list = [prefixes] if prefixes is string else prefixes %}
+
+    {% for prefix in prefix_list %}
+        {# Fetch all schemas that use the current prefix #}
+        {% do log('Fetching schemas for ' + prefix + '...', info=True) %}
+        {% set schemas_table %}
+            select name
+            from sys.schemas
+            where name LIKE '{{prefix}}%'
+        {% endset %}
+        {% set schema_names = run_query(schemas_table).columns[0].values() %}
+
+        {# Test if results are empty #}
+        {% if schema_names is none or schema_names|length == 0 %}
+            {% do log('None found.', info=True) %}
+        {% else %}
+            {# Drop each found schema #}
+            {% for schema_name in schema_names %}
+                {% do log('Dropping schema ' + schema_name, info=True) %}
+                {% do sqlserver__drop_schema_by_name(schema_name) %}
+            {% endfor %}
+        {% endif %}
+    {% endfor %}
+
+{% endmacro %}


### PR DESCRIPTION
Some helper macros have been added to simplify development database cleanup. These are intended to be either run manually as needed or via some pipeline to automatically keep environments in sync with the repo models. Usage is as follows:

Drop all schemas for each prefix with the provided prefix list (dev and myschema being a sample prefixes):
```bash
dbt run-operation sqlserver__drop_schemas_by_prefixes --args "{prefixes: ['dev', 'myschema']}"
```

Drop all schemas with the single provided prefix (dev being a sample prefix):
```bash
dbt run-operation sqlserver__drop_schemas_by_prefixes --args "{prefixes: myschema}"
```

Drop a schema with a specific name (myschema_seed being a sample schema name used in the project):
```bash
dbt run-operation sqlserver__drop_schema_by_name --args "{schema_name: myschema_seed}"
```

Drop any models that are no longer included in the project (dependent on the current target):
```bash
dbt run-operation sqlserver__drop_old_relations
```
or for a dry run to preview dropped models:
```bash
dbt run-operation sqlserver__drop_old_relations --args "{dry_run: true}"