### PR TITLE
Hotfix for Synapse stringTypes and hash type

### DIFF
--- a/macros/dbt_utils/cross_db_utils/datatypes.sql
+++ b/macros/dbt_utils/cross_db_utils/datatypes.sql
@@ -2,6 +2,10 @@
     VARCHAR(900)
 {%- endmacro -%}
 
+{% macro synapse__type_string() %}
+    varchar
+{% endmacro %}
+
 -- TEMP UNTIL synapse is standalone adapter type
 {% macro sqlserver__type_timestamp() %}
     {# in TSQL timestamp is really datetime #}
@@ -18,9 +22,6 @@
     that will make the inheritance of dispatched macros work just like the 
     inheritance of other adapter objects, and render the following code redundant.
 #}
-{% macro synapse__type_string() %}
-    {% do return( tsql_utils.sqlserver__type_string()) %}
-{% endmacro %}
 
 {% macro synapse__type_timestamp() %}
     {% do return( tsql_utils.sqlserver__type_timestamp()) %}

--- a/macros/dbt_utils/cross_db_utils/hash.sql
+++ b/macros/dbt_utils/cross_db_utils/hash.sql
@@ -2,6 +2,10 @@
     convert(varchar(50), hashbytes('md5', {{field}}), 2)
 {% endmacro %}
 
+{% macro synapse__hash(field) %}
+    convert(varchar(50), hashbytes('SHA2_256', {{field}}), 2)
+{% endmacro %}
+
 
 {#
     Imagine an adapter plugin, dbt-synapse, that inherits from dbt-sqlserver.
@@ -12,6 +16,3 @@
     that will make the inheritance of dispatched macros work just like the 
     inheritance of other adapter objects, and render the following code redundant.
 #}
-{% macro synapse__hash(field) %}
-    {% do return( tsql_utils.sqlserver__hash(field)) %}
-{% endmacro %}


### PR DESCRIPTION
Discussed with @swanderz the hotfix for the Azure Synapse stringType and the change in hash setting. MD5 isn't supported anymore, so switched to SHA256.