### PR TITLE
Use VARCHAR(MAX) for String

### DIFF
--- a/macros/dbt_utils/cross_db_utils/datatypes.sql
+++ b/macros/dbt_utils/cross_db_utils/datatypes.sql
@@ -1,5 +1,5 @@
 {% macro sqlserver__type_string() %}
-    VARCHAR(900)
+    VARCHAR(MAX)
 {%- endmacro -%}
 
 -- TEMP UNTIL synapse is standalone adapter type


### PR DESCRIPTION
VARCHAR(MAX) is the closest to "string" type and is available in SQL Server 2005 and up