### PR TITLE
Update references of cross-database macros

### DIFF
--- a/macros/dbt_date/calendar_date/convert_timezones.sql
+++ b/macros/dbt_date/calendar_date/convert_timezones.sql
@@ -1,3 +1,3 @@
 {% macro sqlserver__convert_timezone(column, target_tz, source_tz) -%}
-    CAST({{ column }} as {{ dbt_utils.type_timestamp() }}) AT TIME ZONE '{{ source_tz }}' AT TIME ZONE '{{ target_tz }}'
+    CAST({{ column }} as {{ dbt.type_timestamp() }}) AT TIME ZONE '{{ source_tz }}' AT TIME ZONE '{{ target_tz }}'
 {%- endmacro -%}

--- a/macros/dbt_date/calendar_date/iso_week_of_year.sql
+++ b/macros/dbt_date/calendar_date/iso_week_of_year.sql
@@ -1,3 +1,3 @@
 {%- macro sqlserver__iso_week_of_year(date) -%}
-cast({{ dbt_date.date_part('iso_week', date) }} as {{ dbt_utils.type_int() }}) 
+cast({{ dbt_date.date_part('iso_week', date) }} as {{ dbt.type_int() }}) 
 {%- endmacro %}

--- a/macros/dbt_date/calendar_date/week_of_year.sql
+++ b/macros/dbt_date/calendar_date/week_of_year.sql
@@ -1,3 +1,3 @@
 {%- macro sqlserver__week_of_year(date) -%}
-cast({{ dbt_date.date_part('week', date)}} as {{ dbt_utils.type_int() }})
+cast({{ dbt_date.date_part('week', date)}} as {{ dbt.type_int() }})
 {%- endmacro %}

--- a/macros/dbt_date/calendar_date/week_start.sql
+++ b/macros/dbt_date/calendar_date/week_start.sql
@@ -1,4 +1,4 @@
 {%- macro sqlserver__week_start(date) -%}
 -- Sunday as week start date
-cast({{ dbt_utils.dateadd('day', -1, dbt_utils.date_trunc('week', dbt_utils.dateadd('day', 1, date))) }} as date)
+cast({{ dbt.dateadd('day', -1, dbt.date_trunc('week', dbt.dateadd('day', 1, date))) }} as date)
 {%- endmacro %}

--- a/macros/dbt_expectations/schema_tests/distributional/expect_column_values_to_be_within_n_moving_stdevs.sql
+++ b/macros/dbt_expectations/schema_tests/distributional/expect_column_values_to_be_within_n_moving_stdevs.sql
@@ -35,13 +35,13 @@ coalesce({{ metric_column }}, 0)
 with grouped_metric_values as (
 
         select
-            {{ dbt_utils.date_trunc(period, date_column_name) }} as metric_period,
+            {{ dbt.date_trunc(period, date_column_name) }} as metric_period,
             {{ group_by | join(",") ~ "," if group_by }}
             sum({{ column_name }}) as agg_metric_value
         from
             {{ model }}
         group by
-            {{ dbt_utils.date_trunc(period, date_column_name) }}
+            {{ dbt.date_trunc(period, date_column_name) }}
             {% if group_by %}
                 , {{ group_by | join(",") }}
             {% endif %}
@@ -114,10 +114,10 @@ from
 where
 
     metric_period >= cast(
-            {{ dbt_utils.dateadd(period, -test_periods, dbt_utils.date_trunc(period, dbt_date.now())) }}
-            as {{ dbt_utils.type_timestamp() }})
+            {{ dbt.dateadd(period, -test_periods, dbt.date_trunc(period, dbt_date.now())) }}
+            as {{ dbt.type_timestamp() }})
     and
-    metric_period < {{ dbt_utils.date_trunc(period, dbt_date.now()) }}
+    metric_period < {{ dbt.date_trunc(period, dbt_date.now()) }}
     and
 
     not (

--- a/macros/dbt_utils/cross_db_utils/width_bucket.sql
+++ b/macros/dbt_utils/cross_db_utils/width_bucket.sql
@@ -7,8 +7,8 @@
         -- to break ties when the amount is exactly at the bucket edge
         case
             when
-                {{ dbt_utils.safe_cast(expr, dbt_utils.type_numeric() ) }} %
-                {{ dbt_utils.safe_cast(bin_size, dbt_utils.type_numeric() ) }}
+                {{ dbt.safe_cast(expr, dbt.type_numeric() ) }} %
+                {{ dbt.safe_cast(bin_size, type.type_numeric() ) }}
                  = 0
             then 1
             else 0

--- a/macros/dbt_utils/datetime/date_spine.sql
+++ b/macros/dbt_utils/datetime/date_spine.sql
@@ -54,7 +54,7 @@
 
     rawdata as (
 
-        select top ({{dbt_utils.datediff(start_date, end_date, datepart)}}) rownum -1 as n
+        select top ({{dbt.datediff(start_date, end_date, datepart)}}) rownum -1 as n
         from nums
         order by rownum
     ),
@@ -63,7 +63,7 @@
 
         select (
             {{
-                dbt_utils.dateadd(
+                dbt.dateadd(
                     datepart,
                     'n',
                     start_date

--- a/macros/dbt_utils/schema_tests/sequential_values.sql
+++ b/macros/dbt_utils/schema_tests/sequential_values.sql
@@ -11,7 +11,7 @@
         from {{ model }}
     ) required_alias_for_tsql
     {% if datepart %}
-    where not(cast({{ column_name }} as {{ dbt_utils.type_timestamp() }})= cast({{ dbt_utils.dateadd(datepart, interval, 'previous_' + column_name) }} as {{ dbt_utils.type_timestamp() }}))
+    where not(cast({{ column_name }} as {{ dbt.type_timestamp() }})= cast({{ dbt.dateadd(datepart, interval, 'previous_' + column_name) }} as {{ dbt.type_timestamp() }}))
     {% else %}
     where not({{ column_name }} = previous_{{ column_name }} + {{ interval }})
     {% endif %}

--- a/macros/dbt_utils/sql/surrogate_key.sql
+++ b/macros/dbt_utils/sql/surrogate_key.sql
@@ -78,9 +78,9 @@
     {%- endfor -%}
 
     {%- if use_binary_hash == True -%}
-        {%- set key = "hashbytes('md5', " ~ dbt_utils.concat(fields) ~ ")" -%}
+        {%- set key = "hashbytes('md5', " ~ dbt.concat(fields) ~ ")" -%}
     {%- else -%}
-        {%- set key = dbt_utils.hash(dbt_utils.concat(fields)) -%}
+        {%- set key = dbt.hash(dbt.concat(fields)) -%}
     {%- endif -%}
 
     {{ key }}

--- a/macros/materializations/insert_by_period_helpers.sql
+++ b/macros/materializations/insert_by_period_helpers.sql
@@ -72,14 +72,14 @@
         with data as (
             select
                 coalesce(max({{ timestamp_field }}), '{{ start_date }}') as start_timestamp,
-                coalesce({{ dbt_utils.dateadd('millisecond', 86399999, "nullif('" ~ stop_date | lower ~ "','none')") }},
+                coalesce({{ dbt.dateadd('millisecond', 86399999, "nullif('" ~ stop_date | lower ~ "','none')") }},
                          {{ dbt_utils.current_timestamp() }} ) as stop_timestamp
             from {{ target_schema }}.{{ target_table }}
         )
         select
             start_timestamp,
             stop_timestamp,
-            {{ dbt_utils.datediff('start_timestamp',
+            {{ dbt.datediff('start_timestamp',
                                   'stop_timestamp',
                                   period) }} + 1 as num_periods
         from data


### PR DESCRIPTION
in `dbt-core==1.2.0`, [cross-db macros are moved from dbt-utils into dbt-core global project](https://github.com/dbt-labs/dbt-core/blob/1.2.latest/CHANGELOG.md).

I've checked the [list](https://docs.getdbt.com/reference/dbt-jinja-functions/cross-database-macros) and updated all references.