### PR TITLE
DB name escape fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-
+.vscode
 target/
 dbt_modules/
 logs/

--- a/macros/dbt_utils/schema_cleanup/drop_old_relations.sql
+++ b/macros/dbt_utils/schema_cleanup/drop_old_relations.sql
@@ -19,7 +19,7 @@
                     ELSE concat_ws('.', table_catalog, table_schema, table_name) 
                 END as relation_name
             from
-                "{{ target.database }}".information_schema.tables -- Added quotes for any whitespace in target db
+                [{{ target.database }}].information_schema.tables -- Escape DB name
             where
                 table_schema like '{{ target.schema }}%'
                 and table_name not in (

--- a/macros/dbt_utils/sql/get_tables_by_pattern_sql.sql
+++ b/macros/dbt_utils/sql/get_tables_by_pattern_sql.sql
@@ -3,7 +3,7 @@
         SELECT DISTINCT
             table_schema AS "table_schema",
             table_name AS "table_name"
-        FROM [{{database}}].information_schema.tables
+        FROM [{{database}}].information_schema.tables -- Escape DB name
         WHERE table_schema LIKE '{{ schema_pattern }}'
         AND table_name LIKE '{{ table_pattern }}'
         AND table_name NOT LIKE '{{ exclude }}'

--- a/macros/dbt_utils/sql/get_tables_by_pattern_sql.sql
+++ b/macros/dbt_utils/sql/get_tables_by_pattern_sql.sql
@@ -3,7 +3,7 @@
         SELECT DISTINCT
             table_schema AS "table_schema",
             table_name AS "table_name"
-        FROM {{database}}.information_schema.tables
+        FROM [{{database}}].information_schema.tables
         WHERE table_schema LIKE '{{ schema_pattern }}'
         AND table_name LIKE '{{ table_pattern }}'
         AND table_name NOT LIKE '{{ exclude }}'

--- a/macros/dbt_utils/sql/get_tables_by_pattern_sql.sql
+++ b/macros/dbt_utils/sql/get_tables_by_pattern_sql.sql
@@ -2,7 +2,8 @@
 
         SELECT DISTINCT
             table_schema AS "table_schema",
-            table_name AS "table_name"
+            table_name AS "table_name",
+            {{ dbt_utils.get_table_types_sql() }}
         FROM [{{database}}].information_schema.tables -- Escape DB name
         WHERE table_schema LIKE '{{ schema_pattern }}'
         AND table_name LIKE '{{ table_pattern }}'


### PR DESCRIPTION
This PR is a minor fix to fix TSQL escape characters for some DB utility functions

Changes:
- Added square brackets around DB names in `drop_old_relations.sql` and `get_tables_by_pattern.sql`
- Updates `get_tables_by_pattern` to match the expected dbtutils format