### PR TITLE
add dbt_utils/sqlserver__generate_surrogate_key macro to fix concat bug

### DIFF
--- a/macros/dbt_utils/sql/generate_surrogate_key.sql
+++ b/macros/dbt_utils/sql/generate_surrogate_key.sql
@@ -1,0 +1,29 @@
+{%- macro sqlserver__generate_surrogate_key(field_list) -%}
+
+{%- if var('surrogate_key_treat_nulls_as_empty_strings', False) -%}
+    {%- set default_null_value = "" -%}
+{%- else -%}
+    {%- set default_null_value = '_dbt_utils_surrogate_key_null_' -%}
+{%- endif -%}
+
+{%- set fields = [] -%}
+
+{%- for field in field_list -%}
+
+    {%- do fields.append(
+        "coalesce(cast(" ~ field ~ " as " ~ dbt.type_string() ~ "), '" ~ default_null_value  ~"')"
+    ) -%}
+
+    {%- if not loop.last %}
+        {%- do fields.append("'-'") -%}
+    {%- endif -%}
+
+{%- endfor -%}
+
+{%- if fields|length > 1 %}
+    {{ dbt.hash(dbt.concat(fields)) }}
+{%- else -%}
+    {{ dbt.hash(fields[0]) }}
+{%- endif -%}
+
+{%- endmacro -%}


### PR DESCRIPTION
This fixes the issue with the default generate_surrogate_key macro. The default macro creates a concat statement, even if it has only one column, while sql server requires at least two columns.
I created a macro to generate the surrogate key for SQL server (sqlserver__generate_surrogate_key), adding an if statement before using the concat.

Issue #97 