### PR TITLE
Bug fix proposal on issue related to #96

### DIFF
--- a/macros/dbt_utils/datetime/date_spine.sql
+++ b/macros/dbt_utils/datetime/date_spine.sql
@@ -54,7 +54,7 @@
 
     rawdata as (
 
-        select top ({{dbt_utils.datediff(start_date, end_date, datepart)}}) rownum -1 as n
+        select top ({{dbt.datediff(start_date, end_date, datepart)}}) rownum -1 as n
         from nums
         order by rownum
     ),
@@ -63,7 +63,7 @@
 
         select (
             {{
-                dbt_utils.dateadd(
+                dbt.dateadd(
                     datepart,
                     'n',
                     start_date


### PR DESCRIPTION
I was having an issue working with dbt_utils.date_spine, getting the following error:

![image](https://github.com/joaquinbravo23/tsql-utils/assets/103215772/1659aa0c-7d42-417b-a9e9-6ab3b853ec60)

By making this change the macro worked as expected

`dbt_utils.dateadd` to `dbt.dateadd`
`dbt_utils.datediff` to `dbt.datediff`

I believe this error is due to the following:

> As of dbt 1.3 and dbt_utils 1.0, [cross-database macros](https://docs.getdbt.com/reference/dbt-jinja-functions/cross-database-macros) have moved out of dbt_utils and into the main adapter code ([source](https://docs.getdbt.com/guides/migration/versions/upgrading-to-dbt-utils-v1.0#functionality-now-native-to-dbt-core)), so you can just dbt.datediff()and it will work.
-https://stackoverflow.com/questions/75528600/dbt-datediff-dict-object-compilation-errors

Working as expected
![image](https://github.com/joaquinbravo23/tsql-utils/assets/103215772/0e505145-fda7-48bf-90d0-70f90ab2595e)
