### PR TITLE
Avoid equal_expression from failing dbt tests based on it

### DIFF
--- a/macros/dbt_expectations/schema_tests/_generalized/equal_expression.sql
+++ b/macros/dbt_expectations/schema_tests/_generalized/equal_expression.sql
@@ -72,9 +72,9 @@
     -- select * from final
     select
         {% if return_difference %}
-        coalesce(sum(expression_difference), 0) as final_expression
+        coalesce(expression_difference, 0) as test_results
         {% else %}
-        count(*) as final_expression
+        * as test_results
         {% endif %}
     from final
     where

--- a/macros/dbt_expectations/schema_tests/_generalized/equal_expression.sql
+++ b/macros/dbt_expectations/schema_tests/_generalized/equal_expression.sql
@@ -22,7 +22,9 @@
     {% endif %}
 {% endmacro -%}
 
-{%- macro sqlserver__test_equal_expression(model, expression,
+{%- macro sqlserver__test_equal_expression(
+                                model,
+                                expression,
                                 compare_model,
                                 compare_expression,
                                 group_by,
@@ -30,8 +32,7 @@
                                 row_condition,
                                 compare_row_condition,
                                 tolerance,
-                                tolerance_percent,
-                                return_difference) -%}
+                                tolerance_percent) -%}
 
     {%- set compare_model = model if not compare_model else compare_model -%}
     {%- set compare_expression = expression if not compare_expression else compare_expression -%}
@@ -71,11 +72,7 @@
     -- DEBUG:
     -- select * from final
     select
-        {% if return_difference %}
-        coalesce(expression_difference, 0) as test_results
-        {% else %}
-        * as test_results
-        {% endif %}
+        *
     from final
     where
         {% if tolerance_percent %}

--- a/macros/dbt_expectations/schema_tests/_generalized/equal_expression.sql
+++ b/macros/dbt_expectations/schema_tests/_generalized/equal_expression.sql
@@ -72,9 +72,9 @@
     -- select * from final
     select
         {% if return_difference %}
-        coalesce(sum(expression_difference), 0)
+        coalesce(sum(expression_difference), 0) as final_expression
         {% else %}
-        count(*)
+        count(*) as final_expression
         {% endif %}
     from final
     where


### PR DESCRIPTION
Adding aliases to override of dbt_expectations equal_expression.sql file, would not allow creation of views without specifying column name