### PR TITLE
Uppercase information schema and tables for Fabric compatibility

### DIFF
--- a/macros/dbt_utils/schema_cleanup/drop_old_relations.sql
+++ b/macros/dbt_utils/schema_cleanup/drop_old_relations.sql
@@ -19,7 +19,7 @@
                     ELSE concat_ws('.', table_catalog, table_schema, table_name) 
                 END as relation_name
             from
-                [{{ target.database }}].information_schema.tables -- Escape DB name
+                [{{ target.database }}].INFORMATION_SCHEMA.TABLES -- Escape DB name
             where
                 table_schema like '{{ target.schema }}%'
                 and table_name not in (


### PR DESCRIPTION
When working with MSFT Fabric, drop_old_relations macro fails with the following error:

[Microsoft][ODBC Driver 18 for SQL Server][SQL Server]Invalid object name '<database>.information_schema.tables'.

It wants the table name to be uppercased, which is what this change does. 